### PR TITLE
added an optional "delay" argument to Stepper.step method

### DIFF
--- a/Stepper.py
+++ b/Stepper.py
@@ -35,15 +35,17 @@ class Stepper:
         # Initialize all to 0
         self.reset()
         
-    def step(self, count, direction=1):
+    def step(self, count, direction=1, delay=None):
         """Rotate count steps. direction = -1 means backwards"""
+        if delay == None:
+            delay = self.delay
         for x in range(count):
             for bit in self.mode[::direction]:
                 self.pin1(bit[0])
                 self.pin2(bit[1])
                 self.pin3(bit[2])
                 self.pin4(bit[3])
-                time.sleep_ms(self.delay)
+                time.sleep_ms(delay)
         self.reset()
     def angle(self, r, direction=1):
     	self.step(int(self.FULL_ROTATION * r / 360), direction)


### PR DESCRIPTION
Simply adds the options of adding the delay directly to the step method. If the delay is not added to the step method it will default to the instance delay value, as such should be backwards compatible with previous version. 

I considered using **kwargs but I'm not familiar with the implications in Micropython, if any. 